### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/iplookup.py
+++ b/iplookup.py
@@ -25,9 +25,9 @@
 #
 #  $ mkdir ~/geoip 
 #  $ cd ~/geoip
-#  $ wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
-#  $ wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
-#  $ wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
+#  $ wget https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz
+#  $ wget https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
+#  $ wget https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
 #  $ gunzip *.gz
 #  $ cp ~/Downloads/gagzeqd.py ~/geoip/iplookup.py
 #  $ ./iplookup.py 8.8.8.8


### PR DESCRIPTION
I see that these links are provided in instructions only, however MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).